### PR TITLE
Fix build error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@ import { _A } from "@effect-ts/core/Utils"
 // Service Constructor
 //
 
-export const LoggerId = Symbol()
 
 export const makeLogger = T.succeedWith(() => {
   return service({
@@ -24,6 +23,7 @@ export const makeLogger = T.succeedWith(() => {
 //
 
 export interface Logger extends _A<typeof makeLogger> { }
+export const LoggerId = Symbol()
 export const Logger = tag<Logger>(LoggerId)
 
 // 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { _A } from "@effect-ts/core/Utils"
 export const LoggerId = Symbol()
 
 export const makeLogger = T.succeedWith(() => {
-  return service(LoggerId, {
+  return service({
     log: (s: string) => T.succeedWith(() => {
       console.log(s)
     })


### PR DESCRIPTION
It fixes the following error when building the code:

```
$ tsc --build
src/index.ts:15:28 - error TS2554: Expected 1 arguments, but got 2.

 15   return service(LoggerId, {
                               ~
 16     log: (s: string) => T.succeedWith(() => {
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
... 
 18     })
    ~~~~~~
 19   })
```

I also moved `LoggerId` closed to where it is being used